### PR TITLE
fix broken web links

### DIFF
--- a/src/components/EnterpriseSummaryComponent.js
+++ b/src/components/EnterpriseSummaryComponent.js
@@ -29,10 +29,11 @@ class EnterpriseSummaryComponent extends React.Component {
     var enterprise = this.props.enterprise,
       enterpriseDescription = enterprise.short_description,
       enterpriseLogo = null,
-      enterpriseLink = <Link to={'/enterprise/' + enterprise.id + '/' + slug(enterprise.name)}>{enterprise.name}</Link>,
+      enterpriseRoute = '/enterprise/' + enterprise.id + '/' + slug(enterprise.name),
+      enterpriseLink = <Link to={enterpriseRoute}>{enterprise.name}</Link>,
       moreInfo = (
           <div className="enterprise__website">
-            <Link to={'/enterprise/' + enterprise.id}>{t('enterpriseSummary:moreInfo')}</Link>
+            <Link to={enterpriseRoute}>{t('enterpriseSummary:moreInfo')}</Link>
           </div>
       );
 

--- a/src/components/SocialMediaComponent.js
+++ b/src/components/SocialMediaComponent.js
@@ -41,8 +41,12 @@ class SocialMediaComponent extends React.Component {
     }
 
     if (enterprise.website) {
+      let link = enterprise.website;
+      if (!link.startsWith('http')) {
+        link = 'http://' + link;
+      }
       website = (
-        <a href={enterprise.website} target="_blank" rel="noopener">
+        <a href={link} target="_blank" rel="noopener">
           {t('socialMedia:website')}
         </a>
       );


### PR DESCRIPTION
When web link is defined as "www.paro.ca" the app thinks it is a relative link and get page not found error. Prepending the "http://" if it is not already there seems to fix it

Also, fix the "More Info" link which was not working