### PR TITLE
map: Change tile URL to fetch over https

### DIFF
--- a/src/components/EnterpriseMapComponent.js
+++ b/src/components/EnterpriseMapComponent.js
@@ -42,7 +42,7 @@ class EnterpriseMapComponent extends React.Component {
     return (
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
+        url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       />
     );
   }

--- a/src/components/SearchResultsMapComponent.js
+++ b/src/components/SearchResultsMapComponent.js
@@ -91,7 +91,7 @@ class SearchResultsMapComponent extends React.Component {
     return (
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
+        url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       />
     );
   }


### PR DESCRIPTION
Gets rid of "mix-content" warnings